### PR TITLE
Improvements to support data transfer benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 doc/
 *.o
 *.exe
+*.key
+*.crt

--- a/server-vs-client.c
+++ b/server-vs-client.c
@@ -39,6 +39,8 @@
 #define DATA_WRITES       1
 #define DATA_WRITE_LEN    1
 
+int handshake_count = 1000;
+
 struct result {
   int handshakes;		/* Number of handshakes done. */
   struct timespec cpu;		/* CPU time */
@@ -105,7 +107,7 @@ static int determine_overhead(SSL *ssl, struct result *result) {
 /* Client part */
 static void* client_thread(void *arg) {
   SSL_CTX       *ctx = arg;
-  int           left = 1000;	/* Number of handshakes left */
+  int           left = handshake_count;	/* Number of handshakes left */
   static struct result result;
   result.handshakes = 0;
   result.handshake_read = 0;
@@ -276,20 +278,27 @@ static pthread_t start_server(const char *ciphersuite,
 
 int
 main(int argc, char * const argv[]) {
-  if (argc != 3) {
+  if ((argc != 3)&&(argc != 4)) {
     fprintf(stderr, "Usage: \n");
-    fprintf(stderr, "  %s ciphersuite certificate\n", argv[0]);
+    fprintf(stderr, "  %s ciphersuite certificate [handshakes]\n", argv[0]);
     fprintf(stderr, "\n");
     fprintf(stderr, " - `ciphersuite` is the name of cipher suite to use. Use\n");
     fprintf(stderr, "   `openssl ciphers` to choose one.\n");
     fprintf(stderr, "\n");
     fprintf(stderr, " - `certificate` is the name of the file containing\n");
     fprintf(stderr, "   the certificate, the key and appropriate additional parameters.\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, " - `handshakes` is the number of handshakes you wish to\n");
+    fprintf(stderr, "   test. Defaults to 1000.\n");
     return 1;
   }
 
   const char *ciphersuite = argv[1];
   const char *certificate = argv[2];
+  
+  if (argc == 4) {
+    handshake_count = atoi(argv[3]);
+  }
 
   start("Initialize OpenSSL library");
   SSL_load_error_strings();

--- a/server-vs-client.c
+++ b/server-vs-client.c
@@ -47,11 +47,11 @@ struct result {
   int handshakes;		/* Number of handshakes done. */
   struct timespec cpu_handshake;
   struct timespec cpu;		/* CPU time */
-  size_t handshake_read;
-  size_t handshake_write;
-  size_t data_writes;
-  size_t data_len;
-  size_t enc_data_len;
+  unsigned int handshake_read;
+  unsigned int handshake_write;
+  unsigned int data_writes;
+  unsigned int data_len;
+  unsigned int enc_data_len;
 };
 int       clientserver[2];
 

--- a/server-vs-client.c
+++ b/server-vs-client.c
@@ -389,10 +389,10 @@ main(int argc, char * const argv[]) {
       "Total User CPU time in server: %4ld.%03ld\n"
       "Transfer User CPU time in server: %4ld.%03ld\n"
       "Ratio: %.2f %%\n"
-	    "\n"
-	    "Client handshake bytes received: %d\n"
-	    "Client handshake bytes written: %d\n"      
-	    "TLS record length: %d (data %d, overhead %d)", 
+      "\n"
+      "Client handshake bytes received: %d\n"
+      "Client handshake bytes written: %d\n"      
+      "TLS record length: %d (data %d, overhead %d)", 
       client_result->handshakes,
       client_result->cpu.tv_sec, client_result->cpu.tv_nsec / 1000000,	  
       client_result->cpu.tv_sec - client_result->cpu_handshake.tv_sec, (client_result->cpu.tv_nsec - client_result->cpu_handshake.tv_nsec) / 1000000,	  
@@ -401,10 +401,10 @@ main(int argc, char * const argv[]) {
       server_result->cpu.tv_sec - server_result->cpu_handshake.tv_sec, (server_result->cpu.tv_nsec - server_result->cpu_handshake.tv_nsec) / 1000000,
       (server_result->cpu.tv_sec * 1000. + server_result->cpu.tv_nsec / 1000000.) * 100. /
       (client_result->cpu.tv_sec * 1000. + client_result->cpu.tv_nsec / 1000000.),
-	    client_result->handshake_read,
-	    client_result->handshake_write,
+      client_result->handshake_read,
+      client_result->handshake_write,
       data_write_len + ((client_result->enc_data_len - client_result->data_len) / (client_result->data_writes == 0 ? 1 : client_result->data_writes)),
       data_write_len,
-	    ((client_result->enc_data_len - client_result->data_len) / (client_result->data_writes == 0 ? 1 : client_result->data_writes))
-	  );
+      ((client_result->enc_data_len - client_result->data_len) / (client_result->data_writes == 0 ? 1 : client_result->data_writes))
+  );
 }

--- a/server-vs-client.c
+++ b/server-vs-client.c
@@ -324,8 +324,8 @@ main(int argc, char * const argv[]) {
       "Ratio: %.2f %%\n"
 	    "\n"
 	    "Client handshake bytes received: %d\n"
-	    "Client handshake bytes written: %d\n"	  
-	    "TLS record overhead: %d", 
+	    "Client handshake bytes written: %d\n"      
+	    "TLS record length: %d (data %d, overhead %d)", 
       client_result->handshakes,
       client_result->cpu.tv_sec, client_result->cpu.tv_nsec / 1000000,	  
       server_result->handshakes,
@@ -334,6 +334,8 @@ main(int argc, char * const argv[]) {
       (client_result->cpu.tv_sec * 1000. + client_result->cpu.tv_nsec / 1000000.),
 	    client_result->handshake_read,
 	    client_result->handshake_write,
-	    ((client_result->enc_data_len - client_result->data_len) / client_result->data_writes)
+      DATA_WRITE_LEN + ((client_result->enc_data_len - client_result->data_len) / client_result->data_writes),
+      DATA_WRITE_LEN,
+	    ((client_result->enc_data_len - client_result->data_len) / client_result->data_writes)      
 	  );
 }

--- a/server-vs-client.c
+++ b/server-vs-client.c
@@ -88,7 +88,7 @@ static pthread_t start_client(const char *ciphersuite) {
   SSL_CTX *ctx;
 
   start("Initializing client");
-  if ((ctx = SSL_CTX_new(TLSv1_client_method())) == NULL)
+  if ((ctx = SSL_CTX_new(TLSv1_2_client_method())) == NULL)
     fail("Unable to initialize SSL context:\n%s",
 	 ERR_error_string(ERR_get_error(), NULL));
 

--- a/server-vs-client.c
+++ b/server-vs-client.c
@@ -154,14 +154,14 @@ static void* client_thread(void *arg) {
       }
     }
 		
-	  SSL_shutdown(ssl);
-	  SSL_shutdown(ssl);	   
+    SSL_shutdown(ssl);
+    SSL_shutdown(ssl);	   
     SSL_free(ssl);
 	  continue;
 	
 client_error:
-	  SSL_free(ssl);
-	  break;
+    SSL_free(ssl);
+    break;
   }
      
   clock_gettime(cid, &result.cpu);
@@ -176,7 +176,7 @@ static pthread_t start_client(const char *ciphersuite) {
   start("Initializing client");
   if ((ctx = SSL_CTX_new(TLSv1_2_client_method())) == NULL)
     fail("Unable to initialize SSL context:\n%s",
-	 ERR_error_string(ERR_get_error(), NULL));
+         ERR_error_string(ERR_get_error(), NULL));
 	 
   SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
 	
@@ -186,8 +186,8 @@ static pthread_t start_client(const char *ciphersuite) {
 
   if (SSL_CTX_set_cipher_list(ctx, ciphersuite) != 1)
     fail("Unable to set cipher list to %s:\n%s",
-	 ciphersuite,
-	 ERR_error_string(ERR_get_error(), NULL));
+         ciphersuite,
+         ERR_error_string(ERR_get_error(), NULL));
 
   pthread_t threadid;
   if (pthread_create(&threadid, NULL, &client_thread, ctx))
@@ -215,7 +215,7 @@ static void* server_thread(void *arg) {
     
     clock_gettime(cid, &result.cpu_handshake);
 			
-		int receiving = 1;
+    int receiving = 1;
     while(receiving) {
       int write_back = 0;
       int r = SSL_read(ssl, buf, data_write_len);	
@@ -245,10 +245,10 @@ static void* server_thread(void *arg) {
             goto server_error;
         }	
       }
-		}	
+    }	
 	
-	  SSL_shutdown(ssl);
-	  SSL_shutdown(ssl);    
+    SSL_shutdown(ssl);
+    SSL_shutdown(ssl);    
     SSL_free(ssl);
     continue;
     

--- a/server-vs-client.c
+++ b/server-vs-client.c
@@ -177,6 +177,8 @@ static pthread_t start_client(const char *ciphersuite) {
   if ((ctx = SSL_CTX_new(TLSv1_2_client_method())) == NULL)
     fail("Unable to initialize SSL context:\n%s",
 	 ERR_error_string(ERR_get_error(), NULL));
+	 
+  SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
 	
   #ifdef SSL_OP_NO_COMPRESSION
   SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION);
@@ -278,6 +280,9 @@ static pthread_t start_server(const char *ciphersuite,
     fail("Unable to set cipher list to %s:\n%s",
 	 ciphersuite,
 	 ERR_error_string(ERR_get_error(), NULL));
+
+  /* Disable session caching */	 
+  SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
 
   /* Certificate */
   if (SSL_CTX_use_certificate_chain_file(ctx, certificate) <= 0)


### PR DESCRIPTION
Hi Vincent,

I extended your tool for use of data transfer benchmarking, and improved a few other things along the way:
- Added a data transfer benchmark mode
- Enabled TLS 1.2
- Obtain named curve from the certificate file
- Disabled compression
- Calculation of TLS record overhead

The command line user interface is not the best, but it serves the purpose.
